### PR TITLE
Fix #26: License all files under Apache 2.0

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 import org.gradle.api.JavaVersion

--- a/buildSrc/src/main/kotlin/ProjectConfiguration.kt
+++ b/buildSrc/src/main/kotlin/ProjectConfiguration.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 import com.android.build.api.dsl.BaseFlavor

--- a/library/src/main/java/com/wultra/android/powerauth/networking/Api.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/Api.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 @file:Suppress("unused")

--- a/library/src/main/java/com/wultra/android/powerauth/networking/ECIESInterceptor.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/ECIESInterceptor.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking

--- a/library/src/main/java/com/wultra/android/powerauth/networking/Endpoint.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/Endpoint.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking

--- a/library/src/main/java/com/wultra/android/powerauth/networking/Logger.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/Logger.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking

--- a/library/src/main/java/com/wultra/android/powerauth/networking/data/Requests.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/data/Requests.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2021, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.data

--- a/library/src/main/java/com/wultra/android/powerauth/networking/data/Responses.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/data/Responses.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.data
@@ -22,8 +27,8 @@ open class StatusResponse(@SerializedName("status") val status: Status) {
         @SerializedName("OK")
         OK,
 
-         @SerializedName("ERROR")
-         ERROR
+        @SerializedName("ERROR")
+        ERROR
     }
 }
 

--- a/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiError.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiError.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.error

--- a/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiErrorCode.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiErrorCode.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.error

--- a/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiHttpException.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/error/ApiHttpException.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.error

--- a/library/src/main/java/com/wultra/android/powerauth/networking/error/ErrorResponse.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/error/ErrorResponse.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.error

--- a/library/src/main/java/com/wultra/android/powerauth/networking/error/ErrorResponseObject.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/error/ErrorResponseObject.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.error

--- a/library/src/main/java/com/wultra/android/powerauth/networking/processing/GsonRequestBodyBytes.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/processing/GsonRequestBodyBytes.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.processing

--- a/library/src/main/java/com/wultra/android/powerauth/networking/processing/GsonResponseBodyConverter.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/processing/GsonResponseBodyConverter.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.processing

--- a/library/src/main/java/com/wultra/android/powerauth/networking/ssl/ISSLPinningProvider.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/ssl/ISSLPinningProvider.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.ssl

--- a/library/src/main/java/com/wultra/android/powerauth/networking/ssl/SSLValidationStrategy.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/ssl/SSLValidationStrategy.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.ssl

--- a/library/src/main/java/com/wultra/android/powerauth/networking/ssl/TrustAllCertsTrustManager.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/ssl/TrustAllCertsTrustManager.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2018, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.ssl

--- a/library/src/main/java/com/wultra/android/powerauth/networking/tokens/IPowerAuthTokenListener.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/tokens/IPowerAuthTokenListener.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.tokens

--- a/library/src/main/java/com/wultra/android/powerauth/networking/tokens/IPowerAuthTokenProvider.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/tokens/IPowerAuthTokenProvider.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.tokens

--- a/library/src/main/java/com/wultra/android/powerauth/networking/tokens/TokenManager.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/tokens/TokenManager.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2020, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.tokens

--- a/library/src/main/java/com/wultra/android/powerauth/networking/utils/AppUtils.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/utils/AppUtils.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.utils

--- a/library/src/main/java/com/wultra/android/powerauth/networking/utils/DeviceInfoUtils.kt
+++ b/library/src/main/java/com/wultra/android/powerauth/networking/utils/DeviceInfoUtils.kt
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022, Wultra s.r.o. (www.wultra.com).
+ * Copyright 2022 Wultra s.r.o.
  *
- * All rights reserved. This source code can be used only for purposes specified
- * by the given license contract signed by the rightful deputy of Wultra s.r.o.
- * This source code can be used only by the owner of the license.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Any disputes arising in respect of this agreement (license) shall be brought
- * before the Municipal Court of Prague.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
  */
 
 package com.wultra.android.powerauth.networking.utils


### PR DESCRIPTION
This PR changes commercial license to Apache 2.0 in all source files.