### PR TITLE
Improve R8 rules

### DIFF
--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -5,5 +5,5 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keepclasseswithmembers class com.wultra.android.powerauth.networking.data.** { *; }
--keepclasseswithmembers class com.wultra.android.powerauth.networking.error.** { *; }
+-keepclasseswithmembers, allowobfuscation class com.wultra.android.powerauth.networking.data.** { *; }
+-keepclasseswithmembers, allowobfuscation class com.wultra.android.powerauth.networking.error.** { *; }

--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -5,5 +5,5 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keepclassmembers class com.wultra.android.powerauth.networking.data.** { *; }
--keepclassmembers class com.wultra.android.powerauth.networking.error.** { *; }
+-keepclasseswithmembers class com.wultra.android.powerauth.networking.data.** { *; }
+-keepclasseswithmembers class com.wultra.android.powerauth.networking.error.** { *; }

--- a/library/consumer-proguard-rules.pro
+++ b/library/consumer-proguard-rules.pro
@@ -5,5 +5,12 @@
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keepclasseswithmembers, allowobfuscation class com.wultra.android.powerauth.networking.data.** { *; }
--keepclasseswithmembers, allowobfuscation class com.wultra.android.powerauth.networking.error.** { *; }
+# keeps fields in the class
+-keepclassmembers class com.wultra.android.powerauth.networking.data.** { <fields>; }
+# handle R8 full mode optimizations
+-keep, allowobfuscation class com.wultra.android.powerauth.networking.data.**
+
+# keeps fields in the class
+-keepclassmembers class com.wultra.android.powerauth.networking.error.** { <fields>; }
+# handle R8 full mode optimizations
+-keep, allowobfuscation class com.wultra.android.powerauth.networking.error.**


### PR DESCRIPTION
Fixes: #64

It was happening that instead of `ApiErrorCode` - null was assigned to `ApiError.error`
This means that during "minification" the whole `ApiErrorCode` enum class was thrown away
